### PR TITLE
Update addon for FastBoot 1.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,12 @@
 /* eslint-env node */
 'use strict';
 
+const path = require('path');
+const Funnel = require('broccoli-funnel');
+const Merge = require('broccoli-merge-trees');
+const fastbootTransform = require('fastboot-transform');
+const existsSync = require('exists-sync');
+
 let FONT_FILES = [
   'Roboto-Thin.woff2',
   'Roboto-Thin.woff',
@@ -39,13 +45,33 @@ module.exports = {
       });
     }
 
-    if (!process.env.EMBER_CLI_FASTBOOT && !(app.options['materialize-shim'] || {}).omitJS) {
-      app.import(`${app.bowerDirectory  }/materialize/dist/js/materialize.js`);
+    if (!(app.options['materialize-shim'] || {}).omitJS) {
+      app.import('vendor/materialize/materialize.js');
       app.import('vendor/materialize-shim.js', {
         exports: {
           materialize: ['default']
         }
       });
     }
+  },
+
+  treeForVendor(tree) {
+    let trees = [];
+
+    if (tree) {
+      trees.push(tree);
+    }
+
+    let materializePath = path.join(this.project.root, this.app.bowerDirectory, 'materialize', 'dist', 'js');
+    if (existsSync(materializePath)) {
+      let materializeTree = fastbootTransform(new Funnel(materializePath, {
+        files: ['materialize.js'],
+        destDir: 'materialize'
+      }));
+
+      trees.push(materializeTree);
+    }
+
+    return new Merge(trees);
   }
 };

--- a/package.json
+++ b/package.json
@@ -56,9 +56,13 @@
     "android"
   ],
   "dependencies": {
+    "broccoli-funnel": "^1.2.0",
+    "broccoli-merge-trees": "^2.0.0",
     "ember-cli-babel": "^6.1.0",
+    "ember-cli-htmlbars": "^2.0.1",
     "ember-cli-sass": "^6.1.3",
-    "ember-cli-htmlbars": "^2.0.1"
+    "exists-sync": "^0.0.4",
+    "fastboot-transform": "^0.1.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/vendor/materialize-shim.js
+++ b/vendor/materialize-shim.js
@@ -1,14 +1,16 @@
-/* globals define, Materialize */
+if (typeof FastBoot === 'undefined') {
+  /* globals define, Materialize */
 
-(function() {
+  (function() {
 
-  function generateModule(name, values) {
-    define(name, [], function() {
-      'use strict';
+    function generateModule(name, values) {
+      define(name, [], function() {
+        'use strict';
 
-      return values;
-    });
-  }
+        return values;
+      });
+    }
 
-  generateModule('materialize', { 'default': Materialize });
-})();
+    generateModule('materialize', { 'default': Materialize });
+  })();
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1165,7 +1165,7 @@ broccoli-funnel-reducer@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/broccoli-funnel-reducer/-/broccoli-funnel-reducer-1.0.0.tgz#11365b2a785aec9b17972a36df87eef24c5cc0ea"
 
-broccoli-funnel@^1.0.0, broccoli-funnel@^1.0.1, broccoli-funnel@^1.0.6, broccoli-funnel@^1.1.0:
+broccoli-funnel@^1.0.0, broccoli-funnel@^1.0.1, broccoli-funnel@^1.0.6, broccoli-funnel@^1.1.0, broccoli-funnel@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz#cddc3afc5ff1685a8023488fff74ce6fb5a51296"
   dependencies:
@@ -1304,7 +1304,7 @@ broccoli-sri-hash@^2.1.0:
     sri-toolbox "^0.2.0"
     symlink-or-copy "^1.0.1"
 
-broccoli-stew@^1.2.0, broccoli-stew@^1.3.3:
+broccoli-stew@^1.2.0, broccoli-stew@^1.3.3, broccoli-stew@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/broccoli-stew/-/broccoli-stew-1.5.0.tgz#d7af8c18511dce510e49d308a62e5977f461883c"
   dependencies:
@@ -2712,7 +2712,7 @@ exists-sync@0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/exists-sync/-/exists-sync-0.0.3.tgz#b910000bedbb113b378b82f5f5a7638107622dcf"
 
-exists-sync@0.0.4:
+exists-sync@0.0.4, exists-sync@^0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/exists-sync/-/exists-sync-0.0.4.tgz#9744c2c428cc03b01060db454d4b12f0ef3c8879"
 
@@ -2836,6 +2836,12 @@ fastboot-filter-initializers@0.0.2:
   resolved "https://registry.yarnpkg.com/fastboot-filter-initializers/-/fastboot-filter-initializers-0.0.2.tgz#67aa9e8b22ca4b0e6a244f2450fd1cc6befa45e7"
   dependencies:
     broccoli-funnel "^1.0.1"
+
+fastboot-transform@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/fastboot-transform/-/fastboot-transform-0.1.0.tgz#c00c3c4f376b4e788278cec5cb8d35488e083c07"
+  dependencies:
+    broccoli-stew "^1.5.0"
 
 fastboot@1.0.0-rc.6, fastboot@^1.0.0-rc.3:
   version "1.0.0-rc.6"


### PR DESCRIPTION
This change wraps the browser specific libraries with if (typeof FastBoot === 'undefined') {...} check so that they are eval'd and run in browser but only eval'd and skipped in Node.

This prepares the addon for the upcoming FastBoot 1.0. See ember-fastboot/ember-cli-fastboot#387

cc: @mike-north 